### PR TITLE
Add a groupId substition because it looks like maven archetype is

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ used to launch appropriate feature. When running, simple textual substitutions a
 `@KAWAIMPORT` - gets replaced by directory, containing extraced library code. Meant to be used with kawa's `-Dkawa.import.path`.
 `@SEPARATOR` - gets replaced by path separator character; `;` on windows, `:` on unix.
 `@PROJECTROOT` - absolute path of maven project. 
+`@GROUPID` - the groupId of the maven project.
 
 As an example, default compile behavior is equivalent to following explicit configuration
 

--- a/src/main/java/com/github/arvyy/kawaplugin/MavenKawaInvoker.java
+++ b/src/main/java/com/github/arvyy/kawaplugin/MavenKawaInvoker.java
@@ -54,8 +54,9 @@ public class MavenKawaInvoker {
         extractKawaLibraries(mavenProject, path);
         var expandedCommandTemplate = commandTemplate.stream()
                 .map(part -> part.replace("@KAWAIMPORT",  path.toAbsolutePath().toString())
-                                .replace("@PROJECTROOT", mavenProject.getBasedir().getAbsolutePath())
-                        .replace("@SEPARATOR", File.pathSeparator)
+                                 .replace("@PROJECTROOT", mavenProject.getBasedir().getAbsolutePath())
+                                 .replace("@SEPARATOR", File.pathSeparator)
+                                 .replace("@GROUPID", mavenProject.getGroupId())
                 )
                 .collect(Collectors.toList());
         log.debug("Using classpath " + classpath);


### PR DESCRIPTION
creating a directory with the name of the groupId, e.g. where the groupId is xyz: src/main/webapp/xyz/WEB-INF/